### PR TITLE
Removal of spray dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: scala
 scala:
   - 2.12.4
-  - 2.11.11
+  - 2.11.12
 env:
   - JDK=oraclejdk8
   - JDK=openjdk7 # Oracle JDK7 is end-of-life

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: scala
 scala:
-  - 2.10.4
-  - 2.11.5
+  - 2.11.8
 jdk:
   - oraclejdk7
   - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,22 @@
+dist: trusty
 language: scala
 scala:
-  - 2.11.8
-jdk:
-  - oraclejdk7
-  - openjdk6
+  - 2.12.4
+  - 2.11.11
+env:
+  - JDK=oraclejdk8
+  - JDK=openjdk7 # Oracle JDK7 is end-of-life
+  - JDK=openjdk6 # Oracle JDK6 is end-of-life
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+before_script:
+  - jdk_switcher use $JDK
+matrix:
+  # scala 2.12 requires java 8
+  exclude:
+    - scala: 2.12.4
+      env: JDK=oraclejdk7
+    - scala: 2.12.4
+      env: JDK=openjdk6

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ pomExtra := {
 
 // Build
 
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+crossScalaVersions := Seq("2.11.11", "2.12.4")
 
 scalaVersion := crossScalaVersions.value.last
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,16 +34,22 @@ pomExtra := {
 
 // Build
 
-crossScalaVersions := Seq("2.11.8")
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 scalaVersion := crossScalaVersions.value.last
 
 scalacOptions ++= Seq("-unchecked", "-feature", "-deprecation")
 
+scalacOptions += {
+    CrossVersion partialVersion scalaVersion.value match {
+        case Some((x, y)) if x >= 2 && y >= 12 ⇒ "-target:jvm-1.8"
+        case _ ⇒ "-target:jvm-1.6"
+    }
+}
+
 libraryDependencies ++= Seq(
     Deps.akkaActor % Provided,
-    Deps.activemqClient % Provided,
-    Deps.sprayUtil
+    Deps.activemqClient % Provided
 )
 
 libraryDependencies ++= Seq(
@@ -57,16 +63,6 @@ libraryDependencies ++= Seq(
     Deps.logback,
     Deps.scalaTest
 ) map (_ % Test)
-
-//libraryDependencies += {
-//    CrossVersion partialVersion scalaVersion.value match {
-//        case Some((2, 10)) => Deps.ficus2_10
-//        case Some((2, 11)) => Deps.ficus2_11
-//        case _ => sys.error("Ficus dependency needs updating")
-//    }
-//} % Test
-//
-//publishArtifact in Test := true
 
 autoAPIMappings := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ pomExtra := {
 
 // Build
 
-crossScalaVersions := Seq("2.11.11", "2.12.4")
+crossScalaVersions := Seq("2.11.12", "2.12.4")
 
 scalaVersion := crossScalaVersions.value.last
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -20,5 +20,4 @@ object Deps {
     val jclOverSlf4j = "org.slf4j" % "jcl-over-slf4j" % Versions.slf4j
     val logback = "ch.qos.logback" % "logback-classic" % Versions.logback
     val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest
-    val sprayUtil = "io.spray" %% "spray-util" % Versions.spray
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,9 +8,8 @@
 
 object Versions {
   val activemq = "5.9.1"
-  val akka = "2.4.7"
+  val akka = "2.4.19"
   val logback = "1.1.2"
-  val scalaTest = "2.2.1"
+  val scalaTest = "3.0.4"
   val slf4j = "1.7.7"
-  val spray = "1.3.2"
 }

--- a/src/main/scala/com/codemettle/reactivemq/Producer.scala
+++ b/src/main/scala/com/codemettle/reactivemq/Producer.scala
@@ -96,9 +96,7 @@ trait Producer extends Actor with TwoWayCapable with ActorLogging {
 
                 if (swallowSendStatus) {
                     implicit val timeout = Timeout(sendTimeout + 5.seconds)
-                    (connection ? sendMessage) onFailure {
-                        case t ⇒ self ! LogError(t, newMsg)
-                    }
+                    (connection ? sendMessage).failed.foreach(t ⇒ self ! LogError(t, newMsg))
                 } else {
                     connection forward sendMessage
                 }

--- a/src/main/scala/com/codemettle/reactivemq/ReActiveMQExtension.scala
+++ b/src/main/scala/com/codemettle/reactivemq/ReActiveMQExtension.scala
@@ -57,7 +57,7 @@ class ReActiveMQExtensionImpl(config: ReActiveMQConfig)(implicit system: Extende
     val autoConnects: Map[String, ActorRef] = Try {
         import system.dispatcher
         import akka.pattern.ask
-        import spray.util.pimpFuture
+        import com.codemettle.reactivemq.util._
         implicit val timeout = Timeout(config.autoconnectTimeout + 2.seconds)
 
         val futures = config.autoConnections map (e ⇒ (manager ? AutoConnect(e._2, e._1, config.autoconnectTimeout)).mapTo[ConnectionEstablished])

--- a/src/main/scala/com/codemettle/reactivemq/config/ReActiveMQConfig.scala
+++ b/src/main/scala/com/codemettle/reactivemq/config/ReActiveMQConfig.scala
@@ -11,7 +11,8 @@ package config
 import java.{util ⇒ ju}
 
 import com.typesafe.config.{Config, ConfigObject, ConfigValue, ConfigValueType}
-import spray.util.SettingsCompanion
+
+import com.codemettle.reactivemq.util.SettingsCompanion
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration

--- a/src/main/scala/com/codemettle/reactivemq/package.scala
+++ b/src/main/scala/com/codemettle/reactivemq/package.scala
@@ -7,9 +7,9 @@
  */
 package com.codemettle
 
-import com.typesafe.config.{Config, ConfigException}
+import com.typesafe.config.Config
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 /**
  * @author steven
@@ -17,17 +17,10 @@ import scala.concurrent.duration.FiniteDuration
  */
 package object reactivemq {
     implicit class RichConfig(val u: Config) extends AnyVal {
-        def getFiniteDuration(path: String): FiniteDuration = {
-            import spray.util.pimpConfig
-
-            pimpConfig(u).getDuration(path) match {
+        def getFiniteDuration(path: String): FiniteDuration =
+            u.getDuration(path).toNanos.nanos.toCoarsest match {
                 case fd: FiniteDuration ⇒ fd
-                case _ ⇒ throw new ConfigException.BadValue(path, "Not a FiniteDuration")
+                case _ ⇒ sys.error("can't happen")
             }
-        }
-    }
-
-    implicit class OldOption[T](val u: Option[T]) extends AnyVal {
-        def contains(item: T) = u exists (_ == item)
     }
 }

--- a/src/main/scala/com/codemettle/reactivemq/util/SettingsCompanion.scala
+++ b/src/main/scala/com/codemettle/reactivemq/util/SettingsCompanion.scala
@@ -1,0 +1,25 @@
+package com.codemettle.reactivemq.util
+
+import com.typesafe.config.Config
+
+import akka.actor.{ActorRefFactory, ActorSystem}
+
+/**
+  * Created by steven on 9/19/2017.
+  *
+  * I've looked at spray and akka source before, so this isn't clean room or anything
+  */
+abstract class SettingsCompanion[T](path: String) {
+  private var cache = Map.empty[ActorSystem, T]
+
+  private def materialize(system: ActorSystem): T =
+    cache.getOrElse(system, {
+      val t = fromSubConfig(system.settings.config.getConfig(path))
+      cache += (system → t)
+      t
+    })
+
+  def apply(arf: ActorRefFactory): T = materialize(actorSystem(arf))
+
+  def fromSubConfig(c: Config): T
+}

--- a/src/main/scala/com/codemettle/reactivemq/util/package.scala
+++ b/src/main/scala/com/codemettle/reactivemq/util/package.scala
@@ -1,0 +1,25 @@
+package com.codemettle.reactivemq
+
+import akka.actor.{ActorContext, ActorRefFactory, ActorSystem}
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.language.implicitConversions
+
+/**
+  * Created by steven on 9/19/2017.
+  */
+package object util {
+  implicit def actorSystem(implicit arf: ActorRefFactory): ActorSystem = arf match {
+    case as: ActorSystem ⇒ as
+    case ac: ActorContext ⇒ ac.system
+    case _ ⇒ sys.error(s"Unsupported ActorRefFactory $arf")
+  }
+
+  implicit class RichFuture[T](val u: Future[T]) extends AnyVal {
+    def await(implicit timeout: Duration = 1.minute): T =
+      Await.result(u, timeout)
+
+    def ready(implicit timeout: Duration = 1.minute): Future[T] =
+      Await.ready(u, timeout)
+  }
+}

--- a/src/test/scala/com/codemettle/reactivemq/config/TestReActiveMQConfig.scala
+++ b/src/test/scala/com/codemettle/reactivemq/config/TestReActiveMQConfig.scala
@@ -10,6 +10,8 @@ package com.codemettle.reactivemq.config
 import com.typesafe.config.ConfigFactory
 import org.scalatest._
 
+import com.codemettle.reactivemq.util._
+
 import akka.actor.ActorSystem
 import scala.concurrent.duration._
 import scala.util.control.Exception.ultimately
@@ -21,7 +23,10 @@ import scala.util.control.Exception.ultimately
 class TestReActiveMQConfig extends FlatSpec with Matchers with OptionValues {
     private def confTestCfg(cfg: String)(f: (ReActiveMQConfig) ⇒ Unit) = {
         val system = ActorSystem("Test", ConfigFactory parseString cfg withFallback ConfigFactory.load())
-        ultimately(system.shutdown()) {
+
+        def shutdown() = system.terminate().await
+
+        ultimately(shutdown()) {
             f(ReActiveMQConfig(system))
         }
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.1-SNAPSHOT"
+version in ThisBuild := "1.5.0-SNAPSHOT"


### PR DESCRIPTION
Saw I still had #1 open.
This pull request removes the dependency on spray-util, the last non-provided dependency of the project.
Besides removing a transitive dependency with a fixed version, this would also allow for cross-compilation to Scala 2.12 (see #2).

If this pull request is accepted, I'll update my branch for #2 and send a subsequent pull request for that one.