### PR TITLE
Add support for BytesMessage

### DIFF
--- a/src/main/scala/com/codemettle/reactivemq/activemq/ConnectionFactory.scala
+++ b/src/main/scala/com/codemettle/reactivemq/activemq/ConnectionFactory.scala
@@ -10,7 +10,7 @@ package com.codemettle.reactivemq.activemq
 import javax.jms
 
 import org.apache.activemq.ActiveMQConnectionFactory
-import org.apache.activemq.command.{ActiveMQObjectMessage, ActiveMQTextMessage}
+import org.apache.activemq.command.{ActiveMQBytesMessage, ActiveMQObjectMessage, ActiveMQTextMessage}
 import java.{io ⇒ jio}
 import com.codemettle.reactivemq.activemq.ConnectionFactory.{Connection, ConnectionKey}
 import com.codemettle.reactivemq.model.{TempTopic, TempQueue}
@@ -61,6 +61,12 @@ private[reactivemq] object ConnectionFactory {
         def createObjectMessage(obj: jio.Serializable): jms.ObjectMessage = {
             val msg = new ActiveMQObjectMessage
             msg setObject obj
+            msg
+        }
+
+        def createBytesMessage(data: => Array[Byte]): jms.BytesMessage = {
+            val msg = new ActiveMQBytesMessage
+            msg writeBytes data
             msg
         }
     }

--- a/src/test/scala/com/codemettle/reactivemq/model/TestAMQMessage.scala
+++ b/src/test/scala/com/codemettle/reactivemq/model/TestAMQMessage.scala
@@ -7,7 +7,10 @@
  */
 package com.codemettle.reactivemq.model
 
+import org.apache.activemq.command.ActiveMQBytesMessage
 import org.scalatest._
+
+import scala.util.Random
 
 /**
  * @author steven
@@ -35,5 +38,48 @@ class TestAMQMessage extends FlatSpec with Matchers {
         val msg = AMQMessage(Topic("test"))
 
         a[ClassCastException] shouldBe thrownBy (msg.bodyAs[String])
+    }
+    "A bytes message" should "read the data into a byte[]" in {
+        val data = {
+            val d = new Array[Byte](32)
+            Random.nextBytes(d)
+            d
+        }
+        val msg = AMQMessage(data)
+
+        msg.bodyAs[Array[Byte]] should equal(data)
+    }
+    it should "fail for messages that are too large" in {
+        val msgLen: Long = Int.MaxValue.toLong + 10
+        val msg = new ActiveMQBytesMessage() {
+            override def getBodyLength: Long = msgLen
+        }
+        the[RuntimeException] thrownBy
+            AMQMessage.from(msg) should have message s"Message too large, unable to read $msgLen bytes of data"
+    }
+    it should "work with buffered data that is presented in chunks" in {
+        val data: Array[Byte] = {
+            val arr = new Array[Byte](2048)
+            Random.nextBytes(arr)
+            arr
+        }
+        val amqMessage = new ActiveMQBytesMessage() {
+            lazy val queue = {
+                val q = scala.collection.mutable.Queue[Array[Byte]]()
+                data.grouped(64).foreach(q.enqueue(_))
+                q
+            }
+            override val getBodyLength: Long = queue.map(_.length).sum
+
+            override def readBytes(array: Array[Byte]): Int = {
+                val d = queue.dequeue
+                d.zipWithIndex.foreach { case (b, idx) => array.update(idx, b) }
+                d.length
+            }
+        }
+
+        val msg = AMQMessage.from(amqMessage)
+        msg.bodyAs[Array[Byte]].length should equal(data.length)
+        msg.bodyAs[Array[Byte]] should equal(data)
     }
 }


### PR DESCRIPTION
A quick implementation for BytesMessage.
Performance wise this is far from optimised (especially for bigger messages).
Had an initial implementation using akka.util.ByteString, but it seemed counter-intuitive compared to Array[Byte]. 

Also snuck in a AMQMessage#withType(String) helper method.