### PR TITLE
Upgraded ActiveMQ version from 5.15.3 to 5.16.0

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -7,7 +7,7 @@
  */
 
 object Versions {
-  val activemq = "5.15.3"
+  val activemq = "5.16.0"
   val akka = "2.5.23"
   val camel = "2.21.0"
   val logback = "1.1.2"

--- a/src/test/scala/com/codemettle/reactivemq/VmBrokerTests.scala
+++ b/src/test/scala/com/codemettle/reactivemq/VmBrokerTests.scala
@@ -109,6 +109,9 @@ class VmBrokerTests(_system: ActorSystem) extends TestKit(_system) with FlatSpec
     override protected def beforeAll(): Unit = {
         setLogging()
 
+        // Needed post-5.15.3 for some reason to serialize Integer.
+        System.setProperty("org.apache.activemq.SERIALIZABLE_PACKAGES", "java.lang")
+
         startBroker()
 
         val p = Promise[Unit]()


### PR DESCRIPTION
Upgraded ActiveMQ version from 5.15.3 to 5.16.0 (latest at the time of this commit). Added a call to set java.lang as a Serializable Package for the broker in VmBrokerTests (this seems to be required post-upgrade; not sure why it wasn't before).